### PR TITLE
Adding an ipython notebook to split the dataset for ssd7

### DIFF
--- a/ssd7_data_splitting.ipynb
+++ b/ssd7_data_splitting.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# import libraries\n",
+    "import pandas as pd\n",
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# load udacity consolidated driving dataset labels\n",
+    "dataset = pd.read_csv('path/to/udacity_driving_datasets/labels.csv', header=0, sep=',',low_memory=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# get image filenames and splitting them in train and val sets\n",
+    "dataset_filenames = dataset.frame.unique()\n",
+    "train_names, val_names = train_test_split(dataset_filenames, test_size=0.2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# extract train and val set from dataframe\n",
+    "train = dataset.loc[dataset['frame'].isin(train_names)]\n",
+    "val = dataset.loc[dataset['frame'].isin(val_names)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# save to csv\n",
+    "train.to_csv('../../datasets/udacity_driving_datasets/train_labels.csv',index=False)\n",
+    "val.to_csv('../../datasets/udacity_driving_datasets/val_labels.csv',index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The pull request adds a notebook to facilitate the usage of the ssd7 example. Once obtained the consolidated car dataset from udacity, the notebook allows to split the `labels.csv` file in `train.csv` and `val.csv` to proceed with the training of the model.