### PR TITLE
fix for case where some classes don't have predictions

### DIFF
--- a/eval_utils/average_precision_evaluator.py
+++ b/eval_utils/average_precision_evaluator.py
@@ -617,6 +617,10 @@ class Evaluator:
                 print("No predictions for class {}/{}".format(class_id, self.n_classes))
                 true_positives.append(true_pos)
                 false_positives.append(false_pos)
+                cumulative_true_pos = np.cumsum(true_pos) # Cumulative sums of the true positives
+                cumulative_false_pos = np.cumsum(false_pos) # Cumulative sums of the false positives
+                cumulative_true_positives.append(cumulative_true_pos)
+                cumulative_false_positives.append(cumulative_false_pos)
                 continue
 
             # Convert the predictions list for this class into a structured array so that we can sort it by confidence.


### PR DESCRIPTION
Running the following code in `ssd300_evaluation.ipynb` for my own dataset:

```
evaluator = Evaluator(model=model,
                      n_classes=n_classes,
                      data_generator=dataset,
                      model_mode=model_mode)

results = evaluator(img_height=img_height,
                    img_width=img_width,
                    batch_size=4,
                    data_generator_mode='resize',
                    round_confidences=False,
                    matching_iou_threshold=0.5,
                    border_pixels='include',
                    sorting_algorithm='quicksort',
                    average_precision_mode='sample',
                    num_recall_points=11,
                    ignore_neutral_boxes=True,
                    return_precisions=True,
                    return_recalls=True,
                    return_average_precisions=True,
                    verbose=True)

mean_average_precision, average_precisions, precisions, recalls = results
```
Gave the following result:

```
Number of images in the evaluation dataset: 610

Producing predictions batch-wise: 100%|██████████| 153/153 [45:12<00:00, 17.73s/it]
Matching predictions to ground truth, class 1/3.: 100%|██████████| 121648/121648 [00:07<00:00, 16603.31it/s]
Matching predictions to ground truth, class 2/3.: 100%|██████████| 352/352 [00:00<00:00, 20737.05it/s]
No predictions for class 3/3
Computing precisions and recalls, class 1/3
Computing precisions and recalls, class 2/3
Computing precisions and recalls, class 3/3

---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-7-0d14d966be9b> in <module>()
     18                     return_recalls=True,
     19                     return_average_precisions=True,
---> 20                     verbose=True)
     21 
     22 mean_average_precision, average_precisions, precisions, recalls = results

~/Documents/projects/ssd_keras/eval_utils/average_precision_evaluator.py in __call__(self, img_height, img_width, batch_size, data_generator_mode, round_confidences, matching_iou_threshold, border_pixels, sorting_algorithm, average_precision_mode, num_recall_points, ignore_neutral_boxes, return_precisions, return_recalls, return_average_precisions, verbose, decoding_confidence_thresh, decoding_iou_threshold, decoding_top_k, decoding_pred_coords, decoding_normalize_coords)
    224         #############################################################################################
    225 
--> 226         self.compute_precision_recall(verbose=verbose, ret=False)
    227 
    228         #############################################################################################

~/Documents/projects/ssd_keras/eval_utils/average_precision_evaluator.py in compute_precision_recall(self, verbose, ret)
    765                 print("Computing precisions and recalls, class {}/{}".format(class_id, self.n_classes))
    766 
--> 767             tp = self.cumulative_true_positives[class_id]
    768             fp = self.cumulative_false_positives[class_id]
    769 

IndexError: list index out of range
```

It seems there's a bug when there are no detections for a class. When there *are* detections, [these lines](https://github.com/pierluigiferrari/ssd_keras/blob/3ac9adaf3889f1020d74b0eeefea281d5e82f353/eval_utils/average_precision_evaluator.py#L721) keep track of both the detections and the cumulative detection scores:

```
true_positives.append(true_pos)
false_positives.append(false_pos)

cumulative_true_pos = np.cumsum(true_pos) # Cumulative sums of the true positives
cumulative_false_pos = np.cumsum(false_pos) # Cumulative sums of the false positives

cumulative_true_positives.append(cumulative_true_pos)
cumulative_false_positives.append(cumulative_false_pos)
```

 However, when there aren't any detections, [these few lines](https://github.com/pierluigiferrari/ssd_keras/blob/3ac9adaf3889f1020d74b0eeefea281d5e82f353/eval_utils/average_precision_evaluator.py#L618) append the empty `true_pos` and `false_pos` to `true_positives` and `false_positives`, respectively, but `cumulative_true_positives` and `cumulative_false_positives` remain untouched:

```
# In case there are no predictions at all for this class, we're done here.
if len(predictions) == 0:
    print("No predictions for class {}/{}".format(class_id, self.n_classes))
    true_positives.append(true_pos)
    false_positives.append(false_pos)
    continue
```

Thus, when it's time to calculate the precision-recall curve, `self.cumulative_true_positives[class_id]` doesn't exist.

Appending the empty `true_pos` and `false_pos` arrays to `cumulative_true_pos` and `cumulative_false_pos`, respectively, as per this merge request, seems to fix the issue.