### PR TITLE
Fix match_predictions to handle non-verbose case

### DIFF
--- a/eval_utils/average_precision_evaluator.py
+++ b/eval_utils/average_precision_evaluator.py
@@ -641,7 +641,7 @@ class Evaluator:
                 tr = trange(len(predictions), file=sys.stdout)
                 tr.set_description("Matching predictions to ground truth, class {}/{}.".format(class_id, self.n_classes))
             else:
-                tr = range(len(predictions.shape))
+                tr = range(len(predictions))
 
             # Keep track of which ground truth boxes were already matched to a detection.
             gt_matched = {}


### PR DESCRIPTION
Proposed fixed for the match_predictions function found in average_precision_evaluator module:
- if verbose is False the current code doesn't loop over all predictions and hence produces lower mAp values
- the code has been fixed to handle this case