### PR TITLE
chore: Changed default value of 'normalized_coords'

### DIFF
--- a/ssd_encoder_decoder/ssd_input_encoder.py
+++ b/ssd_encoder_decoder/ssd_input_encoder.py
@@ -53,7 +53,7 @@ class SSDInputEncoder:
                  neg_iou_limit=0.3,
                  border_pixels='half',
                  coords='centroids',
-                 normalize_coords=True,
+                 normalize_coords=False,
                  background_id=0):
         '''
         Arguments:


### PR DESCRIPTION
The default value in ssd_input_encoder now matches all model constructor's default values.